### PR TITLE
Fix a minor spell error in cmake files

### DIFF
--- a/cmake/external_libs/isl.cmake
+++ b/cmake/external_libs/isl.cmake
@@ -1,5 +1,5 @@
 set(isl_USE_STATIC_LIBS ON)
-set(isl_CONFIG_FILE_DIR "-DISL_WARP_DIR=${AKG_SOURCE_DIR}/third_party/isl_wrap")
+set(isl_CONFIG_FILE_DIR "-DISL_WRAP_DIR=${AKG_SOURCE_DIR}/third_party/isl_wrap")
 set(isl_DEPEND_INCLUDE_DIR "-DGMP_INCLUDE_DIR=${GMP_INCLUDE_DIR}")
 set(isl_DEPEND_LIB_DIR "-DGMP_LIBRARY=${GMP_LIBRARY}")
 akg_add_pkg(isl

--- a/third_party/isl_wrap/CMakeLists.txt
+++ b/third_party/isl_wrap/CMakeLists.txt
@@ -3,9 +3,9 @@ set(ISL_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 message("ISL_DIR: ${ISL_DIR}")
 message("GMP_INCLUDE_DIR: ${GMP_INCLUDE_DIR}")
 message("GMP_LIBRARY: ${GMP_LIBRARY}")
-message("ISL_WARP_DIR: ${ISL_WARP_DIR}")
+message("ISL_WRAP_DIR: ${ISL_WRAP_DIR}")
 
-include_directories("${ISL_WARP_DIR}/include")
+include_directories("${ISL_WRAP_DIR}/include")
 include_directories("${ISL_DIR}/include")
 include_directories("${ISL_DIR}")
 
@@ -127,7 +127,7 @@ execute_process(
   WORKING_DIRECTORY ${ISL_DIR}
   OUTPUT_VARIABLE ISL_GIT_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE)
-configure_file("${ISL_WARP_DIR}/gitversion.h.in" "gitversion.h")
+configure_file("${ISL_WRAP_DIR}/gitversion.h.in" "gitversion.h")
 
 install(TARGETS isl_fixed)
 file(GLOB HEAD_FILE_LIST ${ISL_DIR}/*.h)


### PR DESCRIPTION
The cmake variable ISL_WRAP_DIR is misspelt as WARP, which is error-causing. Wondering if you guys are crazy about CUDA . 